### PR TITLE
Add workflow to automatically update neovim plugins using lazy

### DIFF
--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -1,0 +1,46 @@
+name: Update Neovim Plugins
+
+on:
+  schedule:
+    # Run Daily
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Lazy update
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Install Neovim
+        run: |
+          brew install nvim
+
+      - name: Symlink dotfiles
+        run: |
+          BASE_PATH="$(git rev-parse --show-toplevel)"
+          ln -s "$BASE_PATH/.config/nvim" "$HOME/.config/nvim"
+
+      - name: Run Updates
+        id: update
+        run: |
+          nvim --version
+          nvim --headless "+Lazy! update" +qa!
+          echo "updated_plugins<<EOF" >> $GITHUB_OUTPUT
+          git diff | awk 'NR>6 && /^\+/ { print $2 }' | cut -d'"' -f2 | sed 's/^/- /' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: main
+          branch: lazy-update
+          commit-message: Update lazy-lock
+          title: Update lazy-lock
+          body: |
+            Updated plugins:
+
+            ${{ steps.update.outputs.updated_plugins }}


### PR DESCRIPTION
The workflow is run daily and uses only macos runner due these configurations are only meant for macos.

The workflow performs the following steps:

1. Setup homebrew
2. Install neovim using homebrew
3. Symlink .config/nvim to the action HOME folder
4. Run `lazy update` and parse the updated plugins from git diff and set them into github output (markdown list format)
5. Create pull-request against main with the changes to the lazy-lock file

The workflow will force-push any updates to existing branch so even if the PR is not merged it will get updated with the latest updates.